### PR TITLE
Fix broken Vuex modules' names

### DIFF
--- a/src/bootstrap/drivers/vuex-bootstrapper.ts
+++ b/src/bootstrap/drivers/vuex-bootstrapper.ts
@@ -14,7 +14,7 @@ export class VuexBootstrapper implements BootstrapDriver<StoreStack> {
    * @param callback
    */
   public applyModule (name: string, callback: ContainerFactory): void {
-    Object.assign(this._stack, { name: callback(this.container) })
+    Object.assign(this._stack, { [name]: callback(this.container) })
   }
 
   /**


### PR DESCRIPTION
In the `Object.assign()` call the square brackets were missing, so the value of the `name` argument hasn't been used and instead the Vuex module has been placed under the generic "name" name. Petty mistake, but makes huuuge difference :)